### PR TITLE
Update operator tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make sure aarch64 (32bit is not supported. because of the envoy, with needs goog
 Same as https://istio.io/latest/docs/setup/install/operator, but with `--hub`
 
 ```
-$ istioctl operator init --hub=ghcr.io/resf/istio --tag=1.13.0
+$ istioctl operator init --hub=ghcr.io/resf/istio --tag=1.13.4
 ```
 
 ### Install Istio


### PR DESCRIPTION
The README.md file tries to use the operator with tag 1.13.0 [which does not exist](https://github.com/resf/istio/pkgs/container/istio%2Foperator/versions).
This PR updates the documentation to use the 1.13.4 tag.