### PR TITLE
remove tag on installing operator instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make sure aarch64 (32bit is not supported. because of the envoy, with needs goog
 Same as https://istio.io/latest/docs/setup/install/operator, but with `--hub`
 
 ```
-$ istioctl operator init --hub=ghcr.io/resf/istio --tag=1.13.4
+$ istioctl operator init --hub=ghcr.io/resf/istio
 ```
 
 ### Install Istio


### PR DESCRIPTION
removing the tag in the instruction since the istio installation below it doesn't provide a specific version.
inconsistency of tags can fail the istioctl verify-install such as `envoyfilters.networking.istio.io "stats-filter-1.14" not found`.